### PR TITLE
fix for python 3.7 (http header)

### DIFF
--- a/itbit_api.py
+++ b/itbit_api.py
@@ -159,8 +159,8 @@ class itBitApiConnection(object):
 
         auth_headers = {
             'Authorization': self.clientKey + ':' + signature.decode('utf8'),
-            'X-Auth-Timestamp': timestamp,
-            'X-Auth-Nonce': nonce,
+            'X-Auth-Timestamp': str(timestamp),
+            'X-Auth-Nonce': str(nonce),
             'Content-Type': 'application/json'
         }
 


### PR DESCRIPTION
Without this on python 3.7, the following exception occurs

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/requests/utils.py", line 940, in check_header_validity
    if not pat.match(value):
TypeError: expected string or bytes-like object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "example.py", line 12, in <module>
    wallets = itbit_api_conn.get_all_wallets().json()
  File "/home/paul/dev/getcoins/itbit-test/itbit-restapi-python/itbit_api.py", line 59, in get_all_wallets
    response = self.make_request("GET", path, {})
  File "/home/paul/dev/getcoins/itbit-test/itbit-restapi-python/itbit_api.py", line 168, in make_request
    return requests.request(verb, url, data=json_body, headers=auth_headers)
  File "/usr/lib/python3.7/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python3.7/site-packages/requests/sessions.py", line 498, in request
    prep = self.prepare_request(req)
  File "/usr/lib/python3.7/site-packages/requests/sessions.py", line 441, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/lib/python3.7/site-packages/requests/models.py", line 310, in prepare
    self.prepare_headers(headers)
  File "/usr/lib/python3.7/site-packages/requests/models.py", line 444, in prepare_headers
    check_header_validity(header)
  File "/usr/lib/python3.7/site-packages/requests/utils.py", line 944, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
requests.exceptions.InvalidHeader: Value for header {X-Auth-Timestamp: 1538157247767} must be of type str or bytes, not <class 'int'>
```