### PR TITLE
bugfixes on X-Auth headers

### DIFF
--- a/itbit_api.py
+++ b/itbit_api.py
@@ -159,8 +159,8 @@ class itBitApiConnection(object):
 
         auth_headers = {
             'Authorization': self.clientKey + ':' + signature.decode('utf8'),
-            'X-Auth-Timestamp': timestamp,
-            'X-Auth-Nonce': nonce,
+            'X-Auth-Timestamp': str(timestamp),
+            'X-Auth-Nonce': str(nonce),
             'Content-Type': 'application/json'
         }
 


### PR DESCRIPTION
Fixes:
* `requests.exceptions.InvalidHeader: Value for header {X-Auth-Timestamp: 1577199015593} must be of type str or bytes, not <class 'int'>`
* `requests.exceptions.InvalidHeader: Value for header {X-Auth-Nonce: 1} must be of type str or bytes, not <class 'int'>`

Python 3.7.5
requests 2.22.0